### PR TITLE
Document Bundle Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You'll need the following in order to use these playbooks.
 
 ## Setup
 
-ConductR is **not** provided by this repository. [Contact Typesafe](http://www.typesafe.com/company/contact) to start your ConductR trial.
+ConductR is **not** provided by this repository. Visit the [Customer Portal](https://together.typesafe.com/) to download or [Typesafe.com](https://www.typesafe.com/products/conductr) to sign up to evaluate ConductR.
 
 Copy the ConductR deb installation package into the `conductr/files` folder in your local copy of this repo. The installation package will be uploaded from this folder by the ConductR play to each of the EC2 instances for installation.
 
@@ -67,7 +67,12 @@ ansible-playbook build-cluster-ec2.yml -e "VARS_FILE=vars/{{EC2_REGION}}_vars.ym
 
 ## Accessing cluster applications
 
-If all went well you now have a three node ConductR cluster. Any node in the cluster can serve any application deployed on the cluster. The ELB created by the create network playbook adds a listener on port 80 mapped to the Visualizer on port 9999. Start at least one instance of Visualizer in the cluster and access it using the ELB DNS Name in your browser!
+If all went well you now have a three node ConductR cluster. The nodes are registered with the ELB. In order to access applications from the internet you must add a listener to the ELB and ensure port access. To expose bundle endpoints to the world you must:
+* Add a listener to the ELB. The instance port of the listener will be that of the bundle endpoint.
+* Grant the ELB-SG inbound access on the instance port in to the Node-SG
+* If using ELB ports other than 80 and 44, allow the world, `0.0.0.0/0`, inbound access on the ELB port in to the ELB-SG.
+
+The Visualizer sample application has been setup as an example. Start at least one instance of Visualizer in the cluster. Now you can access the Visualizer sample application using port 80 of the ELB DNS Name in your browser. You may delete or remap the Visualizer ELB listeners and corresponding security group access as desired.
 
 ### Enabling SSL
 
@@ -76,6 +81,8 @@ Add a HTTPS listener to the load balancer in order to access the cluster securel
 ### Optional Variables
 
 The vars file templates contain variables for controlling optional features and components.
+
+`VOL_TYPE` and `VOL_SIZE` determine the type and size (GB) of the storage volume attached to each instance. Use `gp2` for General Purpose (SSD) volumes, `io1` for Provisioned IOPS (SSD) volumes, and `standard` for Magnetic volumes.
 
 `ENABLE_DEBUG` defaults to "false." If set to "true," `-Dakka.loglevel=debug` is added to ConductR's `conf/application.ini` to enable ConductR debug level logging. 
 

--- a/create-network-ec2.yml
+++ b/create-network-ec2.yml
@@ -71,6 +71,7 @@
         vpc_id: "{{ vpc.vpc_id }}"
         region: "{{ vpc.vpc.region }}"
         rules:
+          # SSH
           - proto: tcp
             from_port: 22
             to_port: 22
@@ -117,7 +118,8 @@
           - "{{ vpc.subnets[1].id }}"
           - "{{ vpc.subnets[2].id }}"
         listeners:
-          # Uploads a cert to use SSL
+          # Upload a cert to use SSL
+          # Example listener for Visualizer 80 -> 9999
           - protocol: http
             load_balancer_port: 80
             instance_port: 9999
@@ -132,6 +134,10 @@
       register: elb
 
     - debug: msg="ELB zone name {{ elb.elb.dns_name }}"
+
+    - debug: msg="Add listeners to {{ elb.elb.dns_name }} to expose bundle endpoints"
+
+    - debug: msg="Upload x.509 certificate to ELB for SSL endpoints"
 
     - name: Create vars file
       template:

--- a/templates/vars.j2
+++ b/templates/vars.j2
@@ -1,17 +1,18 @@
 ---
-# Must be set to the key pair name
-# of the file passed to playbook
+# Must be set to the key pair name of the file passed to playbook
 KEYPAIR: "Key Pair Name"
+
 # This image is Ubuntu 14.04 LTS in us-east-1
 # Must set to region local Ubuntu AMI for other regions
 IMAGE: "ami-76b2a71e"
+
 REMOTE_USER: "ubuntu"
 INSTANCE_TYPE: "t2.medium"
 VOL_TYPE: "gp2"
-VOL_SIZE: 20
+VOL_SIZE: 30
 EC2_REGION: "{{ EC2_REGION }}"
 ENABLE_DEBUG: "false"
-INSTALL_DOCKER: "false"
+INSTALL_DOCKER: "true"
 INSTALL_CLI: "true"
 USE_PAPERTRAIL: "false"
 PAPERTRAIL_PORT: "00000"
@@ -25,5 +26,5 @@ AZ_SN2: "{{ vpc.subnets[2].az }}"
 SUBNET2: "{{ vpc.subnets[2].id }}"
 ELB: "{{ elb.elb.name }}"
 TAG_NAME: "ConductR Node"
-CONDUCTR_PKG: "conductr_1.0.9_all.deb"
-CONDCUTR_HAPROXY_PKG: "conductr-haproxy_1.0.9_all.deb"
+CONDUCTR_PKG: "conductr_1.0.11_all.deb"
+CONDCUTR_HAPROXY_PKG: "conductr-haproxy_1.0.11_all.deb"

--- a/vars/vars.yml
+++ b/vars/vars.yml
@@ -1,12 +1,19 @@
 ---
+# Must be set to the key pair name of the file passed to playbook
+KEYPAIR: "Key Pair Name"
+
+# This image is Ubuntu 14.04 LTS in us-east-1
+# Must set to region local Ubuntu AMI for other regions
 IMAGE: "ami-76b2a71e"
+
 REMOTE_USER: "ubuntu"
 INSTANCE_TYPE: "t2.medium"
-KEYPAIR: "My KeyPair Name"
 EC2_REGION: "us-east-1"
 ENABLE_DEBUG: "false"
-INSTALL_DOCKER: "false"
+INSTALL_DOCKER: "true"
 INSTALL_CLI: "true"
+VOL_TYPE: "gp2"
+VOL_SIZE: 30
 NODE_SECURITY_GROUP: "sg-xxxxxxxx"
 AZ_SEED: "us-east-1a"
 SUBNET_SEED: "subnet-xxxxxxxx"
@@ -16,5 +23,5 @@ AZ_SN2: "us-east-1c"
 SUBNET2: "subnet-xxxxxxxx"
 ELB: "My ELB Name"
 TAG_NAME: "ConductR Node"
-CONDUCTR_PKG: "conductr_1.0.2_all.deb"
-CONDCUTR_HAPROXY_PKG: "conductr-haproxy_0.1.0_all.deb"
+CONDUCTR_PKG: "conductr_1.0.11_all.deb"
+CONDCUTR_HAPROXY_PKG: "conductr-haproxy_1.0.11_all.deb"


### PR DESCRIPTION
ELB must be created with at least one listener, we will continue to use Visualizer. This expands documentation on enabling bundle access and provides a message to operators about enabling listeners. Also updates templates.
