### PR TITLE
Further v2 updates

### DIFF
--- a/conductr/tasks/install-agent.yml
+++ b/conductr/tasks/install-agent.yml
@@ -32,24 +32,13 @@
   become: yes
   become_method: sudo
 
-- shell: 'echo -Dconductr.agent.bundle-pidfile-dir={{ CONDUCTR_AGENT_WORK_DIR }}/bundles/pids | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
-  become: yes
-  become_method: sudo
-
-- command: mkdir -p conductr-agent:conductr-agent {{ CONDUCTR_AGENT_WORK_DIR }}/bundles/pids
-  become: yes
-  become_method: sudo
-
-- command: chown -R conductr-agent:conductr-agent {{ CONDUCTR_AGENT_WORK_DIR }}
-  become: yes
-  become_method: sudo
-
 - command: chown conductr-agent:conductr-agent /etc/haproxy/haproxy.cfg
   become: yes
   become_method: sudo
 
-- name: Copy HAProxy restart script
-  copy: src=conductr/files/{{ HAPROXY_RELOAD_SCRIPT }} dest=/usr/bin
+- command: touch /usr/bin/reloadHAProxy.sh
+  become: yes
+  become_method: sudo
 
 - command: chmod 0700 /usr/bin/reloadHAProxy.sh
   become: yes

--- a/templates/vars.j2
+++ b/templates/vars.j2
@@ -26,7 +26,6 @@ TAG_NAME: "ConductR Node"
 CONDUCTR_PKG: "conductr_2.0.0_all.deb"
 CONDUCTR_AGENT_PKG: "conductr-agent_2.0.0_all.deb"
 CONDUCTR_AGENT_WORK_DIR: "/tmp/conductr-agent"
-HAPROXY_RELOAD_SCRIPT: "reloadHAProxy.sh"
 # ConductR 2.*:
 # If you wish to add your own role, uncomment the following
 # In the example below, we are adding a role called `my-role`.


### PR DESCRIPTION
- Removal of the steps to create Agent work directories as it's now done by Agent as part of its startup.
- Ensure `/usr/bin/reloadHAProxy.sh` is available as an empty file with correct file and sudo permission to allow ConductR HAProxy bundle to drop reload script as part of its startup.
