### PR TITLE
WIP - DON'T MERGE - Move /members endpoint to /v2/members

### DIFF
--- a/create-network-ec2.yml
+++ b/create-network-ec2.yml
@@ -126,7 +126,7 @@
         health_check:
             ping_protocol: http
             ping_port: 9005
-            ping_path: /members
+            ping_path: /v2/members
             response_timeout: 5
             interval: 30
             unhealthy_threshold: 2


### PR DESCRIPTION
This is due to v1 of the Control Protocol being dropped from ConductR 2 onwards.
