### PR TITLE
Changes required to support ConductR v2

### DIFF
--- a/create-network-ec2.yml
+++ b/create-network-ec2.yml
@@ -83,8 +83,8 @@
             group_id: "{{ node_sg_name }}"
           # Health
           - proto: tcp
-            from_port: 9005
-            to_port: 9005
+            from_port: 9009
+            to_port: 9009
             group_id: "{{ elb_sg.group_id }}"
           # Visualizer
           - proto: tcp
@@ -145,8 +145,8 @@
             instance_port: 9999
         health_check:
             ping_protocol: http
-            ping_port: 9005
-            ping_path: /members
+            ping_port: 9009
+            ping_path: /status
             response_timeout: 5
             interval: 30
             unhealthy_threshold: 2

--- a/create-network-ec2.yml
+++ b/create-network-ec2.yml
@@ -76,6 +76,11 @@
             from_port: 22
             to_port: 22
             cidr_ip: 0.0.0.0/0
+          # Agent Remote Port
+          - proto: tcp
+            from_port: 2552
+            to_port: 2552
+            group_id: "{{ node_sg_name }}"
           # Health
           - proto: tcp
             from_port: 9005
@@ -91,10 +96,25 @@
             from_port: 9004
             to_port: 9004
             group_name: "{{ node_sg_name }}"
+          # Control protocol
+          - proto: tcp
+            from_port: 9005
+            to_port: 9005
+            group_name: "{{ node_sg_name }}"
           # Bundle transfer
           - proto: tcp
             from_port: 9006
             to_port: 9006
+            group_name: "{{ node_sg_name }}"
+          # ConductR status server
+          - proto: tcp
+            from_port: 9007
+            to_port: 9007
+            group_name: "{{ node_sg_name }}"
+          # Service locator
+          - proto: tcp
+            from_port: 9008
+            to_port: 9008
             group_name: "{{ node_sg_name }}"
           # Bundle endpoint assignments
           - proto: tcp


### PR DESCRIPTION
- Expose connectivity for Control Protocol (port `9005`) between the nodes.
- Modify ELB health check to use Status endpoint provided by ConductR HAProxy.
