### PR TITLE
Install requests library along with conductr-cli

### DIFF
--- a/conductr/tasks/install-core.yml
+++ b/conductr/tasks/install-core.yml
@@ -22,7 +22,7 @@
   register: host_ip
 
 - name: Install ConductR CLI
-  command: pip3 install -U conductr-cli
+  command: pip3 install -U conductr-cli requests
   become: yes
   become_method: sudo
 


### PR DESCRIPTION
This will ensure the requests library is installed according to the required version by conductr-cli.

This behaviour is not required in most OS, but in Ubuntu this is not the case since Ubuntu ships with its own installed debian packaged requests library which is outdated.