### PR TITLE
WIP: 2.0.0 Private Agent Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Ansible Plays for Lightbend ConductR
+# Ansible Plays for Lightbend ConductR - Three Roles Edition
 
 These plays and playbooks provision [Lightbend ConductR](https://conductr.lightbend.com) cluster nodes in AWS EC2 using [Ansible](http://www.ansible.com). ConductR is the project name for Service Orchestration in Lightbend Production Suite.
 
-**This version of ConductR Ansible is compatible with ConductR's Master branch, currently 2.0.x beta.**
+**This version of ConductR Ansible is compatible with ConductR's Master branch, currently 2.0.x rc.**
 For stable branch versions, use the corresponding branch, i.e. Conductr-Ansible 1.1.x branch for use with ConductR 1.1.x.
 
 Use create-network-ec2.yml to setup a new VPC and create your cluster in the new VPC. You only need to provide your access keys and what region to execute in.
 The playbook outputs a vars file for use with the build-cluster-ec.yml.
 
-The playbook build-cluster-ec2.yml launches three instances across three availability zones. ConductR and ConductR-Agent is installed on all instances and configured to form a cluster. The nodes are registered with a load balancer. This playbook can be used with new or existing VPCs.
+The playbook build-cluster-ec2.yml launches three core nodes, three private agents, two public agents and one template node instances across three availability zones. Core, private agent, public agent and template nodes can be of different AMI, instance and volume size.
 
 ## Prerequisites
 
@@ -95,15 +95,25 @@ The vars file templates contain variables for controlling optional features and 
 
 `ENABLE_DEBUG` defaults to "true." When set to "true," `-Dakka.loglevel=debug` is added to ConductR's `conf/application.ini` to enable ConductR debug level logging. Use "false" to disable.
 
+`ENABLE_ROLES` defaults to "true." When set to "true," `-Dconductr.resource-provider.match-offer-roles=on` is added to ConductR's `conf/application.ini` to enable role matching. Use "false" to disable.
+
 `INSTALL_DOCKER` defaults to "true." When set to "true," the Docker apt repository is used to install lxc-docker for ConductR non-root usage. Use "false" to disable.
 
-`CONDUCTR_ROLES` is a list and defaults to `web` and `haproxy` if not specified. To append additional role, e.g. `test` specify the following within the vars file:
+`CONDUCTR_PRIVATE_ROLES` is a list and defaults to `web` and `elasticsearch` if not specified. To append additional role, e.g. `GPU` specify the following within the vars file:
 
 ```
-CONDUCTR_ROLES:
+CONDUCTR_PRIVATE_ROLES:
   - web
-  - haproxy
+  - elasticsearch
   - test
+```
+
+`CONDUCTR_PUBLIC_ROLES` is a list and defaults to `haproxy` if not specified. To append additional role, e.g. `public` specify the following within the vars file:
+
+```
+CONDUCTR_PUBLIC_ROLES:
+  - haproxy
+  - public
 ```
 
 ## Ansible Setup

--- a/build-cluster-ec2.yml
+++ b/build-cluster-ec2.yml
@@ -196,8 +196,6 @@
   sudo: True
 
   vars:
-    CONDUCTR_SEED_PRIVATE_IP:
-      "{{ seeds_private[0] }}"
 # These are the default ConductR Private Agent roles - these roles may be overridden within the VARS_FILE
     CONDUCTR_PRIVATE_AGENT_ROLES:
       - web
@@ -206,9 +204,6 @@
   vars_files:
     - "{{ VARS_FILE }}"
 
-  vars:
-    CONDUCTR_AGENT_ROLES: "{{ CONDUCTR_PRIVATE_AGENT_ROLES }}"
-
   tasks:
     - include: python/tasks/main.yml
     - include: java/tasks/main.yml
@@ -216,6 +211,9 @@
     - include: docker/tasks/main.yml
       when: "{{ INSTALL_DOCKER }} == true"
     - include: conductr/tasks/install-agent.yml
+      vars:
+          CORE_OBSERVER_PRIVATE_IP: "{{ groups.seeds_private[0] }}"
+          CONDUCTR_AGENT_ROLES: "{{ CONDUCTR_PRIVATE_AGENT_ROLES }}"
     - include: bundle/tasks/config-elasticsearch.yml
 
 
@@ -233,9 +231,6 @@
   vars_files:
     - "{{ VARS_FILE }}"
 
-  vars:
-    CONDUCTR_AGENT_ROLES: "{{ CONDUCTR_PUBLIC_AGENT_ROLES }}"
-
   tasks:
     - include: python/tasks/main.yml
     - include: java/tasks/main.yml
@@ -244,8 +239,10 @@
       when: "{{ INSTALL_DOCKER }} == true"
     - include: haproxy/tasks/main.yml
     - include: conductr/tasks/install-agent.yml
+      vars:
+          CORE_OBSERVER_PRIVATE_IP: "{{ groups.seeds_private[0] }}"
+          CONDUCTR_AGENT_ROLES: "{{ CONDUCTR_PUBLIC_AGENT_ROLES }}"
     - include: bundle/tasks/config-haproxy.yml
-    - include: conductr/tasks/install-agent.yml
 
 - name: Install Bundles from the seed node
   hosts: seeds_public

--- a/build-cluster-ec2.yml
+++ b/build-cluster-ec2.yml
@@ -1,4 +1,4 @@
---- 
+---
 - name: Provision and configure a ConductR cluster on AWS
   hosts: localhost
   connection: local
@@ -6,26 +6,27 @@
 
   vars_files:
     - "{{ VARS_FILE }}"
-    
+
   tasks:
-    - name: Launch Seed
+    - name: Launch Core Seed
       local_action:
         module: ec2
-        image: "{{ IMAGE }}"
-        instance_type: "{{ INSTANCE_TYPE }}"
+        image: "{{ CORE_IMAGE }}"
+        instance_type: "{{ CORE_INSTANCE_TYPE }}"
         keypair: "{{ KEYPAIR }}"
         region: "{{ EC2_REGION }}"
-        group_id: "{{ NODE_SECURITY_GROUP }}"
+        group_id: "{{ CORE_SECURITY_GROUP }}"
         vpc_subnet_id: "{{ SUBNET_SEED }}"
         assign_public_ip: yes
         instance_tags:
-          Name: "{{ TAG_NAME }}"
-          Role: Seed Node
+          Name: "{{ TAG_NAME }} Core"
+          Role: Core
+          Seed: True
         count: 1
         volumes:
           - device_name: /dev/sda1
-            device_type: "{{VOL_TYPE }}"
-            volume_size: "{{ VOL_SIZE }}"
+            device_type: "{{ CORE_VOL_TYPE }}"
+            volume_size: "{{ CORE_VOL_SIZE }}"
             delete_on_termination: true
         wait: yes
       register: ec2
@@ -44,27 +45,27 @@
 
     - name: Add public ip to nodes
       add_host:
-        groupname: "nodes"
+        groupname: "core_nodes"
         hostname: "{{ ec2.instances[0].public_ip }}"
 
-    - name: Launch Nodes
+    - name: Launch Core Nodes
       local_action:
         module: ec2
-        image: "{{ IMAGE }}"
-        instance_type: "{{ INSTANCE_TYPE }}"
+        image: "{{ CORE_IMAGE }}"
+        instance_type: "{{ CORE_INSTANCE_TYPE }}"
         keypair: "{{ KEYPAIR }}"
         region: "{{ EC2_REGION }}"
-        group_id: "{{ NODE_SECURITY_GROUP }}"
+        group_id: "{{ CORE_SECURITY_GROUP }}"
         vpc_subnet_id: "{{ item }}"
         assign_public_ip: yes
         instance_tags:
-          Name: "{{ TAG_NAME }}"
-          Role: Node
+          Name: "{{ TAG_NAME }} Core"
+          Role: Core
         count: 1
         volumes:
           - device_name: /dev/sda1
-            device_type: "{{ VOL_TYPE }}"
-            volume_size: "{{ VOL_SIZE }}"
+            device_type: "{{ CORE_VOL_TYPE }}"
+            volume_size: "{{ CORE_VOL_SIZE }}"
             delete_on_termination: true
         wait: yes
       register: ec2
@@ -72,33 +73,112 @@
         - "{{ SUBNET1 }}"
         - "{{ SUBNET2 }}"
 
-    - name: Add public ip to nodes
+    - name: Add public ip to core_nodes
       add_host:
-        groupname: "nodes"
+        groupname: "core_nodes"
         hostname: "{{ item.instances[0].public_ip }}"
       with_items: "{{ ec2.results }}"
 
-    - name: Wait for SSH to come up
-      wait_for:
-        host: "{{ item.instances[0].public_dns_name }}"
-        port: 22
-        delay: 60
-        timeout: 320
-        state: started
+    - name: Launch Private Agent Nodes
+      local_action:
+        module: ec2
+        image: "{{ PRIVATE_AGENT_IMAGE }}"
+        instance_type: "{{ PRIVATE_AGENT_INSTANCE_TYPE }}"
+        keypair: "{{ KEYPAIR }}"
+        region: "{{ EC2_REGION }}"
+        group_id: "{{ PRIVATE_AGENT_SECURITY_GROUP }}"
+        vpc_subnet_id: "{{ item }}"
+        assign_public_ip: yes # ansible access
+        instance_tags:
+          Name: "{{ TAG_NAME }} Private Agent"
+          Role: Private Agent
+        volumes:
+          - device_name: /dev/sda1
+            device_type: "{{ PRIVATE_AGENT_VOL_TYPE }}"
+            volume_size: "{{ PRIVATE_AGENT_VOL_SIZE }}"
+            delete_on_termination: true
+        wait: yes
+      register: ec2
+      with_items:
+        - "{{ SUBNET1 }}"
+        - "{{ SUBNET2 }}"
+        - "{{ SUBNET_SEED }}"
+
+    - name: Add public ip to private_nodes
+      add_host:
+        groupname: "private_nodes"
+        hostname: "{{ item.instances[0].public_ip }}"
       with_items: "{{ ec2.results }}"
 
-- name: Setup ConductR
-  hosts: nodes
+    - name: Launch Public Proxy Nodes
+      local_action:
+        module: ec2
+        image: "{{ PUBLIC_AGENT_IMAGE }}"
+        instance_type: "{{ PUBLIC_AGENT_INSTANCE_TYPE }}"
+        keypair: "{{ KEYPAIR }}"
+        region: "{{ EC2_REGION }}"
+        group_id: "{{ PUBLIC_AGENT_SECURITY_GROUP }}"
+        vpc_subnet_id: "{{ item }}"
+        assign_public_ip: yes
+        instance_tags:
+          Name: "{{ TAG_NAME }} Public Agent"
+          Role: Public Agent
+        count: 1
+        volumes:
+          - device_name: /dev/sda1
+            device_type: "{{ PUBLIC_AGENT_VOL_TYPE }}"
+            volume_size: "{{ PUBLIC_AGENT_VOL_SIZE }}"
+            delete_on_termination: true
+        wait: yes
+      register: ec2
+      with_items:
+        - "{{ SUBNET1 }}"
+        - "{{ SUBNET_SEED }}"
+
+    - name: Add public ip to nodes
+      add_host:
+        groupname: "public_nodes"
+        hostname: "{{ item.instances[0].public_ip }}"
+      with_items: "{{ ec2.results }}"
+
+    - name: Launch Template Nodes
+      local_action:
+        module: ec2
+        image: "{{ TEMPLATE_IMAGE }}"
+        instance_type: "{{ TEMPLATE_INSTANCE_TYPE }}"
+        keypair: "{{ KEYPAIR }}"
+        region: "{{ EC2_REGION }}"
+        group_id: "{{ PRIVATE_AGENT_SECURITY_GROUP }}"
+        vpc_subnet_id: "{{ item }}"
+        assign_public_ip: yes
+        instance_tags:
+          Name: "{{ TAG_NAME }} Template"
+          Role: Template
+        count: 1
+        volumes:
+          - device_name: /dev/sda1
+            device_type: "{{ TEMPLATE_VOL_TYPE }}"
+            volume_size: "{{ TEMPLATE_VOL_SIZE }}"
+            delete_on_termination: true
+        wait: yes
+      register: ec2
+      with_items:
+        - "{{ SUBNET_SEED }}"
+
+    - name: Wait for SSH to come up
+      wait_for:
+       host: "{{ item.instances[0].public_dns_name }}"
+       port: 22
+       delay: 60
+       timeout: 320
+       state: started
+      with_items: "{{ ec2.results }}"
+
+- name: Setup Core Nodes
+  hosts: core_nodes
   user: "{{ REMOTE_USER }}"
   gather_facts: False
   sudo: True
-
-  vars:
-# These are the default ConductR roles - these roles may be overridden within the VARS_FILE
-    CONDUCTR_AGENT_ROLES:
-      - web
-      - haproxy
-      - elasticsearch
 
   vars_files:
     - "{{ VARS_FILE }}"
@@ -106,14 +186,68 @@
   tasks:
     - include: python/tasks/main.yml
     - include: java/tasks/main.yml
+    - include: ntp/tasks/main.yml
+    - include: conductr/tasks/install-core.yml
+
+- name: Setup Private Nodes
+  hosts: private_nodes
+  user: "{{ REMOTE_USER }}"
+  gather_facts: False
+  sudo: True
+
+  vars:
+    CONDUCTR_SEED_PRIVATE_IP:
+      "{{ seeds_private[0] }}"
+# These are the default ConductR Private Agent roles - these roles may be overridden within the VARS_FILE
+    CONDUCTR_PRIVATE_AGENT_ROLES:
+      - web
+      - elasticsearch
+
+  vars_files:
+    - "{{ VARS_FILE }}"
+
+  vars:
+    CONDUCTR_AGENT_ROLES: "{{ CONDUCTR_PRIVATE_AGENT_ROLES }}"
+
+  tasks:
+    - include: python/tasks/main.yml
+    - include: java/tasks/main.yml
+    - include: ntp/tasks/main.yml
     - include: docker/tasks/main.yml
       when: "{{ INSTALL_DOCKER }} == true"
+    - include: conductr/tasks/install-agent.yml
+    - include: bundle/tasks/config-elasticsearch.yml
+
+
+- name: Setup Public Agent Nodes
+  hosts: public_nodes
+  user: "{{ REMOTE_USER }}"
+  gather_facts: False
+  sudo: True
+
+  vars:
+# These are the default ConductR Public Agent roles - these roles may be overridden within the VARS_FILE
+    CONDUCTR_PUBLIC_AGENT_ROLES:
+      - haproxy
+
+  vars_files:
+    - "{{ VARS_FILE }}"
+
+  vars:
+    CONDUCTR_AGENT_ROLES: "{{ CONDUCTR_PUBLIC_AGENT_ROLES }}"
+
+  tasks:
+    - include: python/tasks/main.yml
+    - include: java/tasks/main.yml
     - include: ntp/tasks/main.yml
+    - include: docker/tasks/main.yml
+      when: "{{ INSTALL_DOCKER }} == true"
     - include: haproxy/tasks/main.yml
-    - include: conductr/tasks/install-core.yml
+    - include: conductr/tasks/install-agent.yml
+    - include: bundle/tasks/config-haproxy.yml
     - include: conductr/tasks/install-agent.yml
 
-- name: Install ConductR HAProxy from the seed node
+- name: Install Bundles from the seed node
   hosts: seeds_public
   user: "{{ REMOTE_USER }}"
   gather_facts: True
@@ -124,9 +258,10 @@
 
   tasks:
     - include: "bundle/tasks/install-conductr-haproxy.yml"
+    - include: "bundle/tasks/install-visualizer.yml"
 
-- name: Register ConductR with ELB
-  hosts: nodes
+- name: Register Public Agent Nodes with ELB
+  hosts: public_nodes
   user: "{{ REMOTE_USER }}"
   gather_facts: True
   sudo: True

--- a/bundle/tasks/config-elasticsearch.yml
+++ b/bundle/tasks/config-elasticsearch.yml
@@ -1,0 +1,12 @@
+---
+- command: mkdir -p /var/lib/elasticsearch /var/log/elasticsearch
+  become: yes
+  become_method: sudo
+
+- command: chown conductr-agent:conductr-agent /var/lib/elasticsearch
+  become: yes
+  become_method: sudo
+
+- command: chown conductr-agent:conductr-agent /var/log/elasticsearch
+  become: yes
+  become_method: sudo

--- a/bundle/tasks/config-haproxy.yml
+++ b/bundle/tasks/config-haproxy.yml
@@ -1,0 +1,19 @@
+- command: chown conductr-agent:conductr-agent /etc/haproxy/haproxy.cfg
+  become: yes
+  become_method: sudo
+
+- command: touch /usr/bin/reloadHAProxy.sh
+  become: yes
+  become_method: sudo
+
+- command: chmod 0700 /usr/bin/reloadHAProxy.sh
+  become: yes
+  become_method: sudo
+
+- command: chown conductr-agent:conductr-agent /usr/bin/reloadHAProxy.sh
+  become: yes
+  become_method: sudo
+
+- shell: 'echo "conductr-agent ALL=(root) NOPASSWD: /usr/bin/reloadHAProxy.sh" | sudo tee -a /etc/sudoers'
+  become: yes
+  become_method: sudo

--- a/bundle/tasks/install-conductr-haproxy.yml
+++ b/bundle/tasks/install-conductr-haproxy.yml
@@ -1,13 +1,9 @@
 ---
-- name: Find Bundle - ConductR HAProxy
-  find: paths="/usr/share/conductr/extra" patterns="conductr-haproxy-v*.zip"
-  register: conductr_haproxy_bundle
-
 - shell: "hostname -i"
   register: host_ip
 
 - name: Load Bundle - ConductR HAProxy
-  command: "conduct load --ip {{ host_ip.stdout }} {{ conductr_haproxy_bundle.files[0].path }}"
+  command: "conduct load --ip {{ host_ip.stdout }} conductr-haproxy"
 
 - name: Get HAProxy Nodes
   conductr_agents_get: role="haproxy" conductr_control_host="{{ host_ip.stdout }}"

--- a/bundle/tasks/install-visualizer.yml
+++ b/bundle/tasks/install-visualizer.yml
@@ -1,0 +1,10 @@
+---
+- shell: "hostname -i"
+  register: host_ip
+
+- name: Load Bundle - Visualizer
+  command: "conduct load --ip {{ host_ip.stdout }} visualizer"
+
+- name: Run Bundle
+  command: "conduct run --ip {{ host_ip.stdout}} visualizer"
+

--- a/conductr/tasks/install-agent.yml
+++ b/conductr/tasks/install-agent.yml
@@ -4,6 +4,8 @@
 
 - name: Install ConductR Agent
   apt: deb={{ REMOTE_WORK_DIR }}/{{ CONDUCTR_AGENT_PKG }}
+  vars:
+    CORE_OBSERVER_PRIVATE_IP: {{ groups.seeds_private[0]}}
 
 - command: rm {{ REMOTE_WORK_DIR }}/{{ CONDUCTR_AGENT_PKG }}
 
@@ -13,8 +15,7 @@
   become: yes
   become_method: sudo
 
-- shell: 'echo --core-node {{ groups.seeds_private[0]}}:9004 | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
-  with_items: "{{ groups.seeds_public }}"
+- shell: 'echo --core-node {{ CORE_OBSERVER_PRIVATE_IP }}:9004 | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
   become: yes
   become_method: sudo
 
@@ -39,38 +40,6 @@
   with_indexed_items: "{{ CONDUCTR_AGENT_ROLES }}"
 
 - shell: 'echo -Dconductr.agent.storage-dir={{ CONDUCTR_AGENT_WORK_DIR }}/bundles | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
-  become: yes
-  become_method: sudo
-
-- command: chown conductr-agent:conductr-agent /etc/haproxy/haproxy.cfg
-  become: yes
-  become_method: sudo
-
-- command: touch /usr/bin/reloadHAProxy.sh
-  become: yes
-  become_method: sudo
-
-- command: chmod 0700 /usr/bin/reloadHAProxy.sh
-  become: yes
-  become_method: sudo
-
-- command: chown conductr-agent:conductr-agent /usr/bin/reloadHAProxy.sh
-  become: yes
-  become_method: sudo
-
-- shell: 'echo "conductr-agent ALL=(root) NOPASSWD: /usr/bin/reloadHAProxy.sh" | sudo tee -a /etc/sudoers'
-  become: yes
-  become_method: sudo
-
-- command: mkdir -p /var/lib/elasticsearch /var/log/elasticsearch
-  become: yes
-  become_method: sudo
-
-- command: chown conductr-agent:conductr-agent /var/lib/elasticsearch
-  become: yes
-  become_method: sudo
-
-- command: chown conductr-agent:conductr-agent /var/log/elasticsearch
   become: yes
   become_method: sudo
 

--- a/conductr/tasks/install-agent.yml
+++ b/conductr/tasks/install-agent.yml
@@ -4,8 +4,6 @@
 
 - name: Install ConductR Agent
   apt: deb={{ REMOTE_WORK_DIR }}/{{ CONDUCTR_AGENT_PKG }}
-  vars:
-    CORE_OBSERVER_PRIVATE_IP: {{ groups.seeds_private[0]}}
 
 - command: rm {{ REMOTE_WORK_DIR }}/{{ CONDUCTR_AGENT_PKG }}
 
@@ -30,16 +28,15 @@
 - shell: "cat {{ REMOTE_WORK_DIR }}/az.txt"
   register: az
 
-- shell: 'echo -Dconductr.agent.roles.0={{ az.stdout }} | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
-  become: yes
-  become_method: sudo
+- debug:
+    var: CONDUCTR_AGENT_ROLES
 
-- shell: 'echo -Dconductr.agent.roles.{{ item.0 + 1  }}={{ item.1 }} | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
+- shell: 'echo -Dconductr.agent.roles.{{ item.0 }}={{ item.1 }} | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
   become: yes
   become_method: sudo
   with_indexed_items: "{{ CONDUCTR_AGENT_ROLES }}"
 
-- shell: 'echo -Dconductr.agent.storage-dir={{ CONDUCTR_AGENT_WORK_DIR }}/bundles | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
+- shell: 'echo -Dconductr.agent.roles.{{ CONDUCTR_AGENT_ROLES | length }}={{ az.stdout }} | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
   become: yes
   become_method: sudo
 

--- a/conductr/tasks/install-core.yml
+++ b/conductr/tasks/install-core.yml
@@ -1,11 +1,11 @@
 ---
 - name: Copy ConductR
-  synchronize: src=conductr/files/{{ CONDUCTR_PKG }} dest={{ CONDUCTR_CORE_WORK_DIR }}
+  synchronize: src=conductr/files/{{ CONDUCTR_PKG }} dest={{ REMOTE_WORK_DIR }}
 
 - name: Install ConductR
-  apt: deb={{ CONDUCTR_CORE_WORK_DIR }}/{{ CONDUCTR_PKG }}
+  apt: deb={{ REMOTE_WORK_DIR }}/{{ CONDUCTR_PKG }}
 
-- command: rm {{ CONDUCTR_CORE_WORK_DIR }}/{{ CONDUCTR_PKG }}
+- command: rm {{ REMOTE_WORK_DIR }}/{{ CONDUCTR_PKG }}
 
 - name: Setup Python3 Pip
   apt: name={{ item }} state=latest

--- a/conductr/tasks/install-core.yml
+++ b/conductr/tasks/install-core.yml
@@ -1,13 +1,13 @@
 ---
 - name: Copy ConductR
-  synchronize: src=conductr/files/{{ CONDUCTR_PKG }} dest={{ REMOTE_WORK_DIR }}
+  synchronize: src=conductr/files/{{ CONDUCTR_PKG }} dest={{ CONDUCTR_CORE_WORK_DIR }}
 
 - name: Install ConductR
-  apt: deb={{ REMOTE_WORK_DIR }}/{{ CONDUCTR_PKG }}
+  apt: deb={{ CONDUCTR_CORE_WORK_DIR }}/{{ CONDUCTR_PKG }}
 
-- command: rm {{ REMOTE_WORK_DIR }}/{{ CONDUCTR_PKG }}
+- command: rm {{ CONDUCTR_CORE_WORK_DIR }}/{{ CONDUCTR_PKG }}
 
-- name: Setup Python
+- name: Setup Python3 Pip
   apt: name={{ item }} state=latest
   with_items:
     - python3-pip
@@ -25,6 +25,11 @@
   command: pip3 install -U conductr-cli requests
   become: yes
   become_method: sudo
+
+- shell: 'echo -Dconductr.resource-provider.match-offer-roles=on | sudo tee -a /usr/share/conductr/conf/conductr.ini'
+  become: yes
+  become_method: sudo
+  when: "{{ ENABLE_ROLES }} == true"
 
 - shell: 'echo -Dconductr.ip=$(hostname -i) | sudo tee -a /usr/share/conductr/conf/conductr.ini'
   become: yes

--- a/python/tasks/main.yml
+++ b/python/tasks/main.yml
@@ -1,6 +1,13 @@
 ---
 - name: Install python 2.7
-  raw: apt-get update -qq && apt-get install -qq python2.7
+  raw: apt-get update -qq
+  become: yes
+  become_method: sudo
+
+- name: Install python 2.7
+  raw: apt-get install -qq python2.7
+  become: yes
+  become_method: sudo
 
 - name: create softlink for python 2.7
   raw: rm -f /usr/bin/python && ln -s /usr/bin/python2.7 /usr/bin/python

--- a/templates/vars.j2
+++ b/templates/vars.j2
@@ -2,18 +2,33 @@
 # Must be set to the key pair name of the file passed to playbook
 KEYPAIR: "Key Pair Name"
 
+REMOTE_USER: "ubuntu"
+EC2_REGION: "us-east-1"
+ENABLE_DEBUG: "true"
+ENABLE_ROLES: "true"
+INSTALL_DOCKER: "true"
+
 # This image is Ubuntu 16.04 LTS amd64 hvm:ebs-ssd in us-east-1
 # Must be changed to region local Ubuntu AMI for all other regions
-IMAGE: "ami-40d28157"
+CORE_IMAGE: "ami-e6d5d2f1"
+PRIVATE_AGENT_IMAGE: "ami-e6d5d2f1"
+PUBLIC_AGENT_IMAGE: "ami-e6d5d2f1"
+TEMPLATE_IMAGE: "ami-e6d5d2f1"
 
-REMOTE_USER: "ubuntu"
-REMOTE_WORK_DIR: "/home/ubuntu"
-INSTANCE_TYPE: "t2.medium"
-VOL_TYPE: "gp2"
-VOL_SIZE: 30
-EC2_REGION: "{{ EC2_REGION }}"
-ENABLE_DEBUG: "true"
-INSTALL_DOCKER: "true"
+CORE_INSTANCE_TYPE: "t2.large"
+PRIVATE_AGENT_INSTANCE_TYPE: "t2.xlarge"
+PUBLIC_AGENT_INSTANCE_TYPE: "t2.large"
+TEMPLATE_INSTANCE_TYPE: "t2.small"
+
+CORE_VOL_TYPE: "gp2"
+CORE_VOL_SIZE: 40
+PUBLIC_AGENT_VOL_TYPE: "gp2"
+PUBLIC_AGENT_VOL_SIZE: 40
+PRIVATE_AGENT_VOL_TYPE: "gp2"
+PRIVATE_AGENT_VOL_SIZE: 260
+TEMPLATE_VOL_TYPE: "gp2"
+TEMPLATE_VOL_SIZE: 40
+
 NODE_SECURITY_GROUP: "{{ node_sg.group_id }}"
 AZ_SEED: "{{ vpc.subnets[0].az }}"
 SUBNET_SEED: "{{ vpc.subnets[0].id }}"
@@ -24,6 +39,7 @@ SUBNET2: "{{ vpc.subnets[2].id }}"
 ELB: "{{ elb.elb.name }}"
 TAG_NAME: "Lightbend ConductR Node"
 CONDUCTR_PKG: "conductr_2.0.0_all.deb"
+CONDUCTR_CORE_WORK_DIR: "/tmp"
 CONDUCTR_AGENT_PKG: "conductr-agent_2.0.0_all.deb"
 CONDUCTR_AGENT_WORK_DIR: "/tmp/conductr-agent"
 # ConductR 2.*:

--- a/vars/vars.yml
+++ b/vars/vars.yml
@@ -2,18 +2,37 @@
 # Must be set to the key pair name of the file passed to playbook
 KEYPAIR: "Key Pair Name"
 
-# This image is Ubuntu 16.04 LTS amd64 hvm:ebs-ssd in us-east-1
-# Must be changed to region local Ubuntu AMI for all other regions
-IMAGE: "ami-3ab1fa2d"
-
 REMOTE_USER: "ubuntu"
-INSTANCE_TYPE: "t2.medium"
 EC2_REGION: "us-east-1"
 ENABLE_DEBUG: "true"
+ENABLE_ROLES: "true"
 INSTALL_DOCKER: "true"
-VOL_TYPE: "gp2"
-VOL_SIZE: 60
-NODE_SECURITY_GROUP: "sg-xxxxxxxx"
+
+# This image is Ubuntu 16.04 LTS amd64 hvm:ebs-ssd in us-east-1
+# Must be changed to region local Ubuntu AMI for all other regions
+CORE_IMAGE: "ami-e6d5d2f1"
+PRIVATE_AGENT_IMAGE: "ami-e6d5d2f1"
+PUBLIC_AGENT_IMAGE: "ami-e6d5d2f1"
+TEMPLATE_IMAGE: "ami-e6d5d2f1"
+
+CORE_INSTANCE_TYPE: "t2.large"
+PRIVATE_AGENT_INSTANCE_TYPE: "t2.xlarge"
+PUBLIC_AGENT_INSTANCE_TYPE: "t2.large"
+TEMPLATE_INSTANCE_TYPE: "t2.small"
+
+CORE_VOL_TYPE: "gp2"
+CORE_VOL_SIZE: 40
+PUBLIC_AGENT_VOL_TYPE: "gp2"
+PUBLIC_AGENT_VOL_SIZE: 40
+PRIVATE_AGENT_VOL_TYPE: "gp2"
+PRIVATE_AGENT_VOL_SIZE: 260
+TEMPLATE_VOL_TYPE: "gp2"
+TEMPLATE_VOL_SIZE: 40
+
+CORE_SECURITY_GROUP: "sg-xxxxxxxx"
+PRIVATE_AGENT_SECURITY_GROUP: "sg-xxxxxxxx"
+PUBLIC_AGENT_SECURITY_GROUP: "sg-xxxxxxxx"
+
 AZ_SEED: "us-east-1a"
 SUBNET_SEED: "subnet-xxxxxxxx"
 AZ_SN1: "us-east-1b"
@@ -21,14 +40,19 @@ SUBNET1: "subnet-xxxxxxxx"
 AZ_SN2: "us-east-1c"
 SUBNET2: "subnet-xxxxxxxx"
 ELB: "My ELB Name"
-TAG_NAME: "ConductR Node"
-CONDUCTR_PKG: "conductr_2.0.0-beta.4_all.deb"
-CONDUCTR_AGENT_PKG: "conductr-agent_2.0.0-beta.4_all.deb"
+TAG_NAME: "ConductR"
+CONDUCTR_PKG: "conductr_2.0.0_all.deb"
+CONDUCTR_CORE_WORK_DIR: "/tmp"
+CONDUCTR_AGENT_PKG: "conductr-agent_2.0.0_all.deb"
 CONDUCTR_AGENT_WORK_DIR: "/tmp/conductr-agent"
 # ConductR 2.*:
 # If you wish to add your own role, uncomment the following
-# In the example below, we are adding a role called `my-role`.
-# CONDUCTR_AGENT_ROLES:
+# In the example below, we are adding a role called `my-role`
+# to private agents and my-proxy to public agents.
+# CONDUCTR_PRIVATE_AGENT_ROLES:
 #   - web
-#   - haproxy
+#   - elasticsearch
 #   - my-role
+# CONDUCTR_PUBLIC_AGENT_ROLES:
+#   - haproxy
+#   - my-proxy


### PR DESCRIPTION
This is most of the build cluster mods to build a core, agent and proxy 'three ring' cluster instead of a flat cluster where all three nodes are core, agent and proxy (the 1.1 style).

This config uses more nodes and is not for everyone. This will not all be merged into master as the default approach. Opening a WIP PR for review/discussion.  

Must: Needs create network script.
Should: bundle config tasks should be conditional of results from conductr_agents_get
Would be nice if agents were observed by local AZ cores
