### PR TITLE
Fixes and updates

### DIFF
--- a/conductr/tasks/install-access-token.yml
+++ b/conductr/tasks/install-access-token.yml
@@ -1,9 +1,12 @@
 ---
+- shell: "hostname -i"
+  register: host_ip
+
 - set_fact:
     fact_token: "{{ lookup('file', 'conductr/files/access-token') }}"
 
 - name: Load access-token
-  shell: "conduct load-license <<<  {{ fact_token }}"
+  shell: "conduct load-license --ip {{ host_ip.stdout}} <<<  {{ fact_token }}"
   args:
     executable: /bin/bash
 

--- a/create-private-agent-network-ec2.yml
+++ b/create-private-agent-network-ec2.yml
@@ -14,7 +14,7 @@
 # Must be changed to region local Ubuntu AMI for all other regions
 #
   vars:
-    BASTION_IMAGE: "ami-20631a36"
+    BASTION_IMAGE: "ami-cd0f5cb6"
     BASTION_INSTANCE_TYPE: "t2.large"
     BASTION_VOL_TYPE: "gp2"
     BASTION_VOL_SIZE: 100

--- a/create-private-agent-network-ec2.yml
+++ b/create-private-agent-network-ec2.yml
@@ -246,6 +246,11 @@
             from_port: 10000
             to_port: 10999
             group_name: "{{ core_sg.group_id }}"
+          # Proxy access from ConductR private agents
+          - proto: tcp
+            from_port: 10000
+            to_port: 10999
+            group_name: "{{ private_agent_sg.group_id }}"
           # Proxy access from ConductR public agents
           - proto: tcp
             from_port: 10000

--- a/templates/vars-private-agent.j2
+++ b/templates/vars-private-agent.j2
@@ -2,7 +2,7 @@
 # Must be set to the key pair name of the file passed to playbook
 KEYPAIR: "Set Key Pair Name"
 TAG_NAME: "Lightbend Suite"
-CONDUCTR_VERSION: "2.1.1"
+CONDUCTR_VERSION: "2.1.3"
 EC2_REGION: "{{ EC2_REGION }}"
 EC2_AZ_1: "a"
 EC2_AZ_2: "b"
@@ -55,9 +55,9 @@ SN_PRIVATE_3: "{{ private_SN_C.subnet.id }}"
 
 ELB_NAME: "{{ elb.elb.name }}"
 COMMERCIAL_CREDENTIALS: "my.commercial.credentials"
-CONDUCTR_PKG: "conductr_2.1.1-systemd_all.deb"
+CONDUCTR_PKG: "conductr_2.1.3-systemd_all.deb"
 CONDUCTR_CORE_WORK_DIR: "/tmp"
-CONDUCTR_AGENT_PKG: "conductr-agent_2.1.1-systemd_all.deb"
+CONDUCTR_AGENT_PKG: "conductr-agent_2.1.3-systemd_all.deb"
 CONDUCTR_AGENT_WORK_DIR: "/tmp/conductr-agent"
 
 # ConductR 2.*:

--- a/templates/vars-private-agent.j2
+++ b/templates/vars-private-agent.j2
@@ -17,10 +17,10 @@ AGENT_USER: "conductr-agent"
 #
 # Must be changed to region local Ubuntu AMI for all other regions
 #
-CORE_IMAGE: "ami-20631a36"
-PRIVATE_AGENT_IMAGE: "ami-20631a36"
-PUBLIC_AGENT_IMAGE: "ami-20631a36"
-TEMPLATE_IMAGE: "ami-20631a36"
+CORE_IMAGE: "ami-cd0f5cb6"
+PRIVATE_AGENT_IMAGE: "ami-cd0f5cb6"
+PUBLIC_AGENT_IMAGE: "ami-cd0f5cb6"
+TEMPLATE_IMAGE: "ami-cd0f5cb6"
 
 CORE_INSTANCE_TYPE: "t2.large"
 CORE_VOL_TYPE: "gp2"

--- a/templates/vars.j2
+++ b/templates/vars.j2
@@ -17,9 +17,9 @@ AGENT_USER: "conductr-agent"
 #
 # Must be changed to region local Ubuntu AMI for all other regions
 #
-BASTION_IMAGE: "ami-20631a36"
-NODE_IMAGE: "ami-20631a36"
-TEMPLATE_IMAGE: "ami-20631a36"
+BASTION_IMAGE: "ami-cd0f5cb6"
+NODE_IMAGE: "ami-cd0f5cb6"
+TEMPLATE_IMAGE: "ami-cd0f5cb6"
 
 BASTION_INSTANCE_TYPE: "t2.large"
 BASTION_VOL_TYPE: "gp2"

--- a/templates/vars.j2
+++ b/templates/vars.j2
@@ -1,7 +1,7 @@
 ---
 # Must be set to the key pair name of the file passed to playbook
 KEYPAIR: "Set to Key Pair Name"
-CONDUCTR_VERSION: "2.1.1"
+CONDUCTR_VERSION: "2.1.3"
 TAG_NAME: "Lightbend ConductR"
 EC2_REGION: "{{ EC2_REGION }}"
 EC2_AZ_1: "a"
@@ -41,9 +41,9 @@ SN_3: "{{ vpc.subnets[2].id }}"
 
 ELB_NAME: "{{ elb.elb.name }}"
 COMMERCIAL_CREDENTIALS: "my.commercial.credentials"
-CONDUCTR_PKG: "conductr_2.1.1-systemd_all.deb"
+CONDUCTR_PKG: "conductr_2.1.3-systemd_all.deb"
 CONDUCTR_CORE_WORK_DIR: "/tmp"
-CONDUCTR_AGENT_PKG: "conductr-agent_2.1.1-systemd_all.deb"
+CONDUCTR_AGENT_PKG: "conductr-agent_2.1.3-systemd_all.deb"
 CONDUCTR_AGENT_WORK_DIR: "/tmp/conductr-agent"
 
 # ConductR 2.*:

--- a/vars/bastion-only-vars.yml
+++ b/vars/bastion-only-vars.yml
@@ -15,5 +15,5 @@ BASTION_SG: "sg-xxxxxxxx"
 BASTION_SG: "subnet-xxxxxxxx"
 
 COMMERCIAL_CREDENTIALS: "my.commercial.credentials"
-CONDUCTR_PKG: "conductr_2.1.1-systemd_all.deb"
-CONDUCTR_AGENT_PKG: "conductr-agent_2.1.1-systemd_all.deb"
+CONDUCTR_PKG: "conductr_2.1.3-systemd_all.deb"
+CONDUCTR_AGENT_PKG: "conductr-agent_2.1.3-systemd_all.deb"

--- a/vars/bastion-only-vars.yml
+++ b/vars/bastion-only-vars.yml
@@ -6,7 +6,7 @@ EC2_REGION: "us-east-1"
 REMOTE_USER: "ubuntu"
 # This image is Ubuntu 16.04 LTS amd64 hvm:ebs-ssd in us-east-1
 # Must be changed to region local Ubuntu AMI for all other regions
-BASTION_IMAGE: "ami-20631a36"
+BASTION_IMAGE: "ami-cd0f5cb6"
 BASTION_INSTANCE_TYPE: "t2.large"
 BASTION_VOL_TYPE: "gp2"
 BASTION_VOL_SIZE: 100

--- a/vars/cloudformation.yml
+++ b/vars/cloudformation.yml
@@ -6,7 +6,7 @@ EC2_REGION: "us-east-1"
 REMOTE_USER: "ubuntu"
 # This image is Ubuntu 16.04 LTS amd64 hvm:ebs-ssd in us-east-1
 # Must be changed to region local Ubuntu AMI for all other regions
-IMAGE: "ami-20631a36"
+IMAGE: "ami-cd0f5cb6"
 INSTANCE_TYPE: "t2.micro"
 VOL_TYPE: "gp2"
 VOL_SIZE: 40

--- a/vars/cloudformation.yml
+++ b/vars/cloudformation.yml
@@ -14,8 +14,8 @@ VOL_SIZE: 40
 SG: "sg-xxxxxxxx"
 SN: "subnet-xxxxxxxx"
 
-CONDUCTR_VER: "2.1.1"
-CONDUCTR_PKG: "conductr_2.1.1-systemd_all.deb"
-CONDUCTR_AGENT_PKG: "conductr-agent_2.1.1-systemd_all.deb"
+CONDUCTR_VER: "2.1.3"
+CONDUCTR_PKG: "conductr_2.1.3-systemd_all.deb"
+CONDUCTR_AGENT_PKG: "conductr-agent_2.1.3-systemd_all.deb"
 CONDUCTR_CORE_WORK_DIR: "/tmp"
 CONDUCTR_AGENT_WORK_DIR: "/tmp/conductr-agent"

--- a/vars/vars-private-agent.yml
+++ b/vars/vars-private-agent.yml
@@ -1,7 +1,7 @@
 ---
 # Must be set to the key pair name of the file passed to playbook
 KEYPAIR: "Set to Key Pair Name"
-CONDUCTR_VERSION: 2.1.1
+CONDUCTR_VERSION: 2.1.3
 TAG_NAME: "Lightbend Suite"
 EC2_REGION: "us-east-1"
 EC2_AZ_1: a
@@ -63,9 +63,9 @@ SN_PRIVATE_3: "{{ private_SN_C.subnet.id }}"
 
 ELB_NAME: "Lightbend Suite ELB {{ EC2_REGION }}"
 COMMERCIAL_CREDENTIALS: "my.commercial.credentials"
-CONDUCTR_PKG: "conductr_2.1.1-systemd_all.deb"
+CONDUCTR_PKG: "conductr_2.1.3-systemd_all.deb"
 CONDUCTR_CORE_WORK_DIR: "/tmp"
-CONDUCTR_AGENT_PKG: "conductr-agent_2.1.1-systemd_all.deb"
+CONDUCTR_AGENT_PKG: "conductr-agent_2.1.3-systemd_all.deb"
 CONDUCTR_AGENT_WORK_DIR: "/tmp/conductr-agent"
 
 # ConductR 2.*:

--- a/vars/vars-private-agent.yml
+++ b/vars/vars-private-agent.yml
@@ -19,10 +19,10 @@ AGENT_USER: "conductr-agent"
 # Must be changed to region local Ubuntu AMI for all other regions
 #
 
-CORE_IMAGE: "ami-20631a36"
-PRIVATE_AGENT_IMAGE: "ami-20631a36"
-PUBLIC_AGENT_IMAGE: "ami-20631a36"
-TEMPLATE_IMAGE: "ami-20631a36"
+CORE_IMAGE: "ami-cd0f5cb6"
+PRIVATE_AGENT_IMAGE: "ami-cd0f5cb6"
+PUBLIC_AGENT_IMAGE: "ami-cd0f5cb6"
+TEMPLATE_IMAGE: "ami-cd0f5cb6"
 
 CORE_INSTANCE_TYPE: "t2.large"
 CORE_VOL_TYPE: "gp2"

--- a/vars/vars.yml
+++ b/vars/vars.yml
@@ -18,8 +18,8 @@ AGENT_USER: "conductr-agent"
 #
 # Must be changed to region local Ubuntu AMI for all other regions
 #
-NODE_IMAGE: "ami-20631a36"
-TEMPLATE_IMAGE: "ami-20631a36"
+NODE_IMAGE: "ami-cd0f5cb6"
+TEMPLATE_IMAGE: "ami-cd0f5cb6"
 
 REMOTE_USER: "ubuntu"
 

--- a/vars/vars.yml
+++ b/vars/vars.yml
@@ -1,7 +1,7 @@
 ---
 # Must be set to the key pair name of the file passed to playbook
 KEYPAIR: "Set Key Pair Name"
-CONDUCTR_VERSION: 2.1.1
+CONDUCTR_VERSION: 2.1.3
 TAG_NAME: "Lightbend Enterprise Suite"
 EC2_REGION: "us-east-1"
 EC2_AZ_1: a
@@ -43,9 +43,9 @@ SN_3: "subnet-xxxxxxxx"
 
 ELB_NAME: "Lightbend ELB {{ EC2_REGION }}"
 COMMERCIAL_CREDENTIALS: "my.commercial.credentials"
-CONDUCTR_PKG: "conductr_2.1.1-systemd_all.deb"
+CONDUCTR_PKG: "conductr_2.1.3-systemd_all.deb"
 CONDUCTR_CORE_WORK_DIR: "/tmp"
-CONDUCTR_AGENT_PKG: "conductr-agent_2.1.1-systemd_all.deb"
+CONDUCTR_AGENT_PKG: "conductr-agent_2.1.3-systemd_all.deb"
 CONDUCTR_AGENT_WORK_DIR: "/tmp/conductr-agent"
 
 # ConductR 2.*:


### PR DESCRIPTION
* Adds missing private agent peer access on 10K port range
* Adds "--ip" to install access-token task
* Updates AMI to current LTS images
* Updates version to current release, 2.1.3